### PR TITLE
Last phase changed from 2 to 1

### DIFF
--- a/Assets/Scripts/Driver.cs
+++ b/Assets/Scripts/Driver.cs
@@ -71,7 +71,7 @@ public class Driver : MonoBehaviour
     const float slotTrialDuration = 30f;
     const float parlayTrialDuration = 105f;
     const int lastTrialIndex = 16;
-    const int lastPhase = 2; 
+    const int lastPhase = 1; 
     const float disableTime = 0.5f;
     const float disableButtonBaseline = 1f;
     private ParlayTrialData currentparlayTrial;


### PR DESCRIPTION
When the start screen was disabled it changed the start phase to 0 instead of 1 causing the program to repeat condition 1.