### PR TITLE
Small Patch

### DIFF
--- a/Assets/Scenes/V2.unity
+++ b/Assets/Scenes/V2.unity
@@ -21583,12 +21583,14 @@ MonoBehaviour:
   pokeButtonTutorial: {fileID: 1086453139}
   practiceTutorialBlock: {fileID: 2105702988}
   gazeHandler: {fileID: 1035072719}
+  PracticeButton: {fileID: 1095820560}
+  EasyButton: {fileID: 1541067565}
+  HardButton: {fileID: 2017564712}
   trialCompleted: 0
   goalText: {fileID: 1335624967}
   choicePanel: {fileID: 903084432}
   hardChoiceText: {fileID: 839397927}
   easyChoiceText: {fileID: 157792999}
-  WinProcentText: {fileID: 0}
 --- !u!1001 &1979377702
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/EffortTaskHandler.cs
+++ b/Assets/Scripts/EffortTaskHandler.cs
@@ -19,6 +19,11 @@ public class EffortTaskHandler : MonoBehaviour
     [SerializeField] private GameObject pokeButtonTutorial;
     [SerializeField] private GameObject practiceTutorialBlock;
     [SerializeField] private GazeHandler gazeHandler;
+    [SerializeField] private PokeButton PracticeButton;
+
+    [SerializeField] private PokeButton EasyButton;
+    [SerializeField] private PokeButton HardButton;
+
 
     private const float IntermissionTime = 3f;
 
@@ -41,7 +46,6 @@ public class EffortTaskHandler : MonoBehaviour
     private bool isHardMode = false;
     [SerializeField] private TextMeshPro hardChoiceText;
     [SerializeField] private TextMeshPro easyChoiceText;
-    [SerializeField] private TextMeshPro WinProcentText;
 
     private static readonly float buttonVolume = 0.5f;
     private static readonly float increasePitch = 3f;
@@ -73,7 +77,8 @@ public class EffortTaskHandler : MonoBehaviour
             yield return new WaitForSeconds(3f);
             yield return new WaitUntil(() => sxr.GetTrigger());
             pt1InstructionsPanel.SetActive(false);
-            practice.SetActive(true);            
+            practice.SetActive(true);
+            DisableButtons(true);            
         }
         else
         {
@@ -105,8 +110,8 @@ public class EffortTaskHandler : MonoBehaviour
             intermissionText.text = "Try again";
             practiceTutorialBlock.SetActive(true);
             pokeButtonTutorial.SetActive(true);
-            counter = 0;
-            goalText.text = $"Button Goal:\n{practiceGoal - counter}";
+            PracticeCounter = 0;
+            goalText.text = $"Button Goal:\n{practiceGoal - PracticeCounter}";
         }
     }
 
@@ -114,6 +119,7 @@ public class EffortTaskHandler : MonoBehaviour
     {
         practice.SetActive(false);
         choicePanel.SetActive(true);
+        DisableButtons(false);
         SetChoiceText();
     }
 
@@ -291,5 +297,26 @@ public void AddScore()
             practiceComplete = true;
             StartCountdown();
         }
+    }
+
+    private void DisableButtons(bool practice)
+    {
+        StartCoroutine(TemporarilyDisableButtons(practice));
+    }
+    private IEnumerator TemporarilyDisableButtons(bool practice)
+    {
+        if (practice)
+        {
+            PracticeButton.DisableButton();
+        }
+        EasyButton.DisableButton();
+        HardButton.DisableButton();
+        yield return new WaitForSeconds(0.5f);
+        if (practice)
+        {
+            PracticeButton.EnableButton();
+        }
+        EasyButton.EnableButton();
+        HardButton.EnableButton();
     }
 }


### PR DESCRIPTION
This patch fixes an error with the practiceCounter in the effort task practice round. Also improved UX of the practice/hard/easy buttons by temp disabling them to prevent it from being accidently pressed. removed unused winprocentText from efforttaskhandler