### PR TITLE
Fixed: instructions failing to load

### DIFF
--- a/Assets/Scenes/V2.unity
+++ b/Assets/Scenes/V2.unity
@@ -15932,7 +15932,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   ContextSwitchText: {fileID: 510411508}
   ContextSwitchScene: {fileID: 900306888}
-  Backdrop: {fileID: 0}
+  Backdrop: {fileID: 2082182327}
   PressTriggerGraphic: {fileID: 2140832541}
   parlayInstructions: {fileID: 843408803}
 --- !u!4 &900306890

--- a/Assets/Scripts/SwitchContextText.cs
+++ b/Assets/Scripts/SwitchContextText.cs
@@ -40,6 +40,7 @@ public class SwitchContextText : MonoBehaviour
     private IEnumerator SwitchingToParlayCoroutine()
     {
         Backdrop.SetActive(false);
+        ContextSwitchText.text = "";
         yield return StartCoroutine(parlayInstructions.ShowParlayInstructions());
         Backdrop.SetActive(true);
         for (int i = 0; i < 2; i++)


### PR DESCRIPTION
Backdrop wasn't assigned properly in the inspector causing the program to fail when attempting to switch to parlay instructions.