### PR TITLE
Disabled CheckCameraPosition()

### DIFF
--- a/Assets/Scripts/VRPlayerReposition.cs
+++ b/Assets/Scripts/VRPlayerReposition.cs
@@ -28,34 +28,34 @@ public class VRPlayerReposition : MonoBehaviour
 
     xrRig.position += offset;
 
-    Debug.Log($"[VRPlayerReposition] Moved XR Rig by offset (X,Z only): {offset}");
-    yield return new WaitForSeconds(3.5f);
-    StartCoroutine(CheckCameraPosition());
+    // Debug.Log($"[VRPlayerReposition] Moved XR Rig by offset (X,Z only): {offset}");
+    // yield return new WaitForSeconds(3.5f);
+    // StartCoroutine(CheckCameraPosition());
 }
 
-    private IEnumerator CheckCameraPosition()
-        {
-            Vector3 currentCameraWorldPos = xrCamera.position;
-            Vector3 offset = cameraSpawnPoint.position - currentCameraWorldPos;
-            float currentZ = xrCamera.position.z;
-            float targetZ = cameraSpawnPoint.position.z;
-            if(Vector3.Distance(cameraSpawnPoint.position, currentCameraWorldPos) > 0.35f)
-            {
-                offset = cameraSpawnPoint.position - currentCameraWorldPos;
-                xrRig.position += offset;
-            }
+    // private IEnumerator CheckCameraPosition()
+    //     {
+    //         Vector3 currentCameraWorldPos = xrCamera.position;
+    //         Vector3 offset = cameraSpawnPoint.position - currentCameraWorldPos;
+    //         float currentZ = xrCamera.position.z;
+    //         float targetZ = cameraSpawnPoint.position.z;
+    //         if(Vector3.Distance(cameraSpawnPoint.position, currentCameraWorldPos) > 0.35f)
+    //         {
+    //             offset = cameraSpawnPoint.position - currentCameraWorldPos;
+    //             xrRig.position += offset;
+    //         }
 
-            if(Mathf.Abs(targetZ - currentZ) > 0.25f)
-            {
-                float offsetZ = targetZ - currentZ;
+    //         if(Mathf.Abs(targetZ - currentZ) > 0.25f)
+    //         {
+    //             float offsetZ = targetZ - currentZ;
 
-                Vector3 newPos = xrRig.position;
-                newPos.z += offsetZ;
-                xrRig.position = newPos;
-            }
-            yield return new WaitForSeconds(4f);
-            StartCoroutine(CheckCameraPosition());
-        }
+    //             Vector3 newPos = xrRig.position;
+    //             newPos.z += offsetZ;
+    //             xrRig.position = newPos;
+    //         }
+    //         yield return new WaitForSeconds(4f);
+    //         StartCoroutine(CheckCameraPosition());
+    //     }
 
 
 }


### PR DESCRIPTION
Temporarily disabled constantly checking the camera position and offsetting if they are out of defined bubble. program does still move participant to the center at start but no longer constantly checks after that.