### PR TITLE
Waittime increased

### DIFF
--- a/Assets/Scripts/EffortTaskHandler.cs
+++ b/Assets/Scripts/EffortTaskHandler.cs
@@ -312,7 +312,7 @@ public void AddScore()
         }
         EasyButton.DisableButton();
         HardButton.DisableButton();
-        yield return new WaitForSeconds(0.5f);
+        yield return new WaitForSeconds(1.5f);
         if (practice)
         {
             PracticeButton.EnableButton();


### PR DESCRIPTION
The wait time for pressing the effort task button has been increased from 0.5 to 1.5 seconds to ensure that the participant doesn't accidentally press it.